### PR TITLE
Add withArtboard HOC for Storybook

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,20 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [🔧 Installation](#-installation)
-- [🕹 Usage](#%F0%9F%95%B9-usage)
+- [Installation](#installation)
+- [Usage](#usage)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 Project is still under development!
 
-## 🔧 Installation
+## Installation
 
 ```text
 npm install --save-dev @helpscout/artboard
 ```
 
-## 🕹 Usage
+## Usage
 
 Here's an example Storybook story with Artboard!
 

--- a/src/Artboard/__tests__/Artboard.test.tsx
+++ b/src/Artboard/__tests__/Artboard.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import {mount} from 'enzyme'
-import BoxInspector from './index'
+import Artboard from '../index'
 
 describe('Render', () => {
   test('Can render component', () => {
-    expect(mount(<BoxInspector />)).toBeTruthy()
+    expect(mount(<Artboard />)).toBeTruthy()
   })
 })

--- a/src/ArtboardProvider/__tests__/ArtboardProvider.test.tsx
+++ b/src/ArtboardProvider/__tests__/ArtboardProvider.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {mount} from 'enzyme'
-import Artboard from '../Artboard'
-import ArtboardProvider from './index'
+import Artboard from '../../Artboard/index'
+import ArtboardProvider from '../index'
 
 describe('Render', () => {
   test('Can render component', () => {

--- a/src/BoxInspector/__tests__/BoxInspector.test.tsx
+++ b/src/BoxInspector/__tests__/BoxInspector.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import {mount} from 'enzyme'
-import Resizer from './index'
+import BoxInspector from '../index'
 
 describe('Render', () => {
   test('Can render component', () => {
-    expect(mount(<Resizer />)).toBeTruthy()
+    expect(mount(<BoxInspector />)).toBeTruthy()
   })
 })

--- a/src/Crosshair/__tests__/Crosshair.test.tsx
+++ b/src/Crosshair/__tests__/Crosshair.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {mount} from 'enzyme'
-import Crosshair from './index'
+import Crosshair from '../index'
 
 describe('Render', () => {
   test('Can render component', () => {

--- a/src/Eyedropper/__tests__/Eyedropper.test.tsx
+++ b/src/Eyedropper/__tests__/Eyedropper.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import {mount} from 'enzyme'
-import SizeInspector from './index'
+import Eyedropper from '../index'
 
 describe('Render', () => {
   test('Can render component', () => {
-    expect(mount(<SizeInspector />)).toBeTruthy()
+    expect(mount(<Eyedropper />)).toBeTruthy()
   })
 })

--- a/src/Grid/__tests__/Grid.test.tsx
+++ b/src/Grid/__tests__/Grid.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import {mount} from 'enzyme'
-import Artboard from './index'
+import Grid from '../index'
 
 describe('Render', () => {
   test('Can render component', () => {
-    expect(mount(<Artboard />)).toBeTruthy()
+    expect(mount(<Grid />)).toBeTruthy()
   })
 })

--- a/src/Guide/__tests__/Guide.test.tsx
+++ b/src/Guide/__tests__/Guide.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import {mount} from 'enzyme'
-import Guide from './index'
-import GuideProvider from '../GuideProvider'
-import {dotcx} from '../utils/index'
-import {findOne, getStyle} from '../testHelpers'
+import Guide from '../index'
+import GuideProvider from '../../GuideProvider/index'
+import {dotcx} from '../../utils/index'
+import {findOne, getStyle} from '../../testHelpers'
 
 describe('Width/Height', () => {
   test('Renders with the specified width/height', () => {

--- a/src/GuideContainer/__tests__/GuideContainer.test.tsx
+++ b/src/GuideContainer/__tests__/GuideContainer.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import {mount} from 'enzyme'
-import GuideContainer from './index'
-import Guide from '../Guide'
-import {dotcx} from '../utils/index'
-import {findOne, getStyle} from '../testHelpers'
+import GuideContainer from '../index'
+import Guide from '../../Guide/index'
+import {dotcx} from '../../utils/index'
+import {findOne, getStyle} from '../../testHelpers'
 
 describe('Styles', () => {
   test('Renders CSS-based props as CSS styles', () => {

--- a/src/Resizer/__tests__/Resizer.test.tsx
+++ b/src/Resizer/__tests__/Resizer.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import {mount} from 'enzyme'
-import Eyedropper from './index'
+import Resizer from '../index'
 
 describe('Render', () => {
   test('Can render component', () => {
-    expect(mount(<Eyedropper />)).toBeTruthy()
+    expect(mount(<Resizer />)).toBeTruthy()
   })
 })

--- a/src/SizeInspector/__tests__/SizeInspector.test.tsx
+++ b/src/SizeInspector/__tests__/SizeInspector.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import {mount} from 'enzyme'
-import Grid from './index'
+import SizeInspector from '../index'
 
 describe('Render', () => {
   test('Can render component', () => {
-    expect(mount(<Grid />)).toBeTruthy()
+    expect(mount(<SizeInspector />)).toBeTruthy()
   })
 })

--- a/src/UI/Base/__tests__/Base.test.tsx
+++ b/src/UI/Base/__tests__/Base.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {mount} from 'enzyme'
-import Base from './Base'
-import {getStyle} from '../../testHelpers'
+import Base from '../Base'
+import {getStyle} from '../../../testHelpers'
 
 describe('Base', () => {
   test('Renders a div with default styles', () => {

--- a/src/UI/Button/__tests__/Button.test.tsx
+++ b/src/UI/Button/__tests__/Button.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {mount} from 'enzyme'
-import Button from './Button'
-import {getStyle} from '../../testHelpers'
+import Button from '../Button'
+import {getStyle} from '../../../testHelpers'
 
 describe('Children', () => {
   test('Can render content', () => {

--- a/src/UI/ButtonControl/__tests__/ButtonControl.test.tsx
+++ b/src/UI/ButtonControl/__tests__/ButtonControl.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {mount} from 'enzyme'
-import ButtonControl from './index'
-import {getStyle} from '../../testHelpers'
+import ButtonControl from '../index'
+import {getStyle} from '../../../testHelpers'
 
 describe('Children', () => {
   test('Can render content', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,5 +11,6 @@ export {default as GuideContext} from './GuideContext'
 export {default as GuideProvider} from './GuideProvider'
 export {default as Resizer} from './Resizer'
 export {default as SizeInspector} from './SizeInspector'
+export {default as withArtboard} from './withArtboard'
 
 export default Artboard

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -4,7 +4,7 @@ import {
   toCSSNumberValue,
   cx,
   isInputNode,
-} from './index'
+} from '../index'
 
 describe('noop', () => {
   test('Returns undefined', () => {

--- a/src/withArtboard/__tests__/withArtboard.test.tsx
+++ b/src/withArtboard/__tests__/withArtboard.test.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+import {mount} from 'enzyme'
+import withArtboard from '../withArtboard'
+
+describe('Render', () => {
+  test('Can render component withArtboard', () => {
+    const Component = () => <div />
+    const RenderComponent = () => <Component />
+    const WrappedRenderComponent = withArtboard()(RenderComponent)
+    // @ts-ignore
+    const wrapper = mount(WrappedRenderComponent)
+
+    const el = wrapper.find('Component')
+
+    expect(el.exists()).toBeTruthy()
+  })
+})

--- a/src/withArtboard/index.ts
+++ b/src/withArtboard/index.ts
@@ -1,0 +1,3 @@
+import withArtboard from './withArtboard'
+
+export default withArtboard

--- a/src/withArtboard/withArtboard.tsx
+++ b/src/withArtboard/withArtboard.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react'
+import Artboard from '../Artboard'
+import {Props} from '../Artboard/Artboard.types'
+
+export default function withArtboard(props?: Props) {
+  return render => {
+    return <Artboard {...props}>{render()}</Artboard>
+  }
+}


### PR DESCRIPTION
## Add withArtboard HOC for Storybook

This update adds a withArtboard HOC (decorator) for an easier integration
with Storybook.

Also, *.test.tsx files have been moved into dedicated `__tests__` directories
under their respective domains.